### PR TITLE
Workaround for `moveToFailed()` failing on clusters

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -1,0 +1,12 @@
+'use strict';
+const bunyan = require('bunyan');
+
+const options = {
+    name: 'bull',
+    src: process.env.NODE_ENV === 'development',
+    level: process.env.BUNYAN_DEBUG_LEVEL || 'info',
+    serializers: {
+        err: bunyan.stdSerializers.err
+    }
+};
+module.exports = bunyan.createLogger(options);

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -991,6 +991,12 @@ Queue.prototype.processJob = function(job, notFetch = false) {
   };
 
   const handleFailed = err => {
+
+    console.log('handleFailed');
+    if (this.client instanceof redis.Redis) {
+      console.log('REDIS');
+    }
+
     // log.warn({client: this.client}, 'handleFailed');
     // console.log({client: this.client}); // shows `Cluster {` as the first line on AWS
     /**
@@ -1004,7 +1010,7 @@ Queue.prototype.processJob = function(job, notFetch = false) {
     ) {
       // log.warn({ instance: 'redis.Cluster' }, 'handleFailed');
       return job.moveToCompleted(err, undefined, notFetch).then(jobData => {
-        this.emit('completed', job, err, 'active');
+        this.emit('failed', job, err, 'active');
         return jobData ? this.nextJobFromJobData(jobData[0], jobData[1]) : null;
       });
     }

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -993,9 +993,10 @@ Queue.prototype.processJob = function(job, notFetch = false) {
   const handleFailed = err => {
 
     console.log('handleFailed');
-    if (this.client instanceof redis.Redis) {
-      console.log('REDIS');
-    }
+    console.log(this.client);
+    // if (this.client instanceof redis.Redis) {
+    //   console.log('REDIS');
+    // }
 
     // log.warn({client: this.client}, 'handleFailed');
     // console.log({client: this.client}); // shows `Cluster {` as the first line on AWS

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -991,26 +991,15 @@ Queue.prototype.processJob = function(job, notFetch = false) {
   };
 
   const handleFailed = err => {
-
-    console.log('handleFailed');
-    console.log(redis);
-    console.log(this.client);
-    // if (this.client instanceof redis.Redis) {
-    //   console.log('REDIS');
-    // }
-
-    // log.warn({client: this.client}, 'handleFailed');
-    // console.log({client: this.client}); // shows `Cluster {` as the first line on AWS
     /**
-     * I don't know why instanceof redis.Cluster isn't working
+     * For some reason I can't check `this.client instanceof redis.Cluster`
+     * So instead I'm looking for an option that only exists on a cluster
      */
-    // if (this.client instanceof redis.Cluster) {
     if (
       this.client &&
       this.client.options &&
       this.client.options.retryDelayOnClusterDown
     ) {
-      // log.warn({ instance: 'redis.Cluster' }, 'handleFailed');
       return job.moveToCompleted(err, undefined, notFetch).then(jobData => {
         this.emit('failed', job, err, 'active');
         return jobData ? this.nextJobFromJobData(jobData[0], jobData[1]) : null;

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -994,9 +994,10 @@ Queue.prototype.processJob = function(job, notFetch = false) {
   const handleFailed = err => {
     log.warn({queue: this}, 'handleFailed');
     log.warn({client: this.client}, 'handleFailed');
-    console.log({queue: this});
-    console.log({client: this.client});
-    if (this.client instanceof redis.Cluster) {
+    // console.log({queue: this});
+    // console.log({client: this.client});
+    // if (this.client instanceof redis.Cluster) {
+    if (this.client.options.retryDelayOnClusterDown) {
       log.warn({instance: 'redis.Cluster'}, 'handleFailed');
       return job.moveToCompleted(err, undefined, notFetch).then(jobData => {
         this.emit('completed', job, err, 'active');

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -996,6 +996,10 @@ Queue.prototype.processJob = function(job, notFetch = false) {
   };
 
   const handleFailed = err => {
+    console.log('handleFailed');
+    console.log(this.client);
+    console.log('handleFailed JSON');
+    console.log(JSON.stringify(this.client));
     // return job.moveToCompleted(err, undefined, notFetch).then(jobData => {
     //   this.emit('completed', job, err, 'active');
     //   return jobData ? this.nextJobFromJobData(jobData[0], jobData[1]) : null;

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -995,6 +995,7 @@ Queue.prototype.processJob = function(job, notFetch = false) {
      * For some reason I can't check `this.client instanceof redis.Cluster`
      * So instead I'm looking for an option that only exists on a cluster
      */
+    log.warn({client: this.client}, 'handleFailed');
     if (
       this.client &&
       this.client.options &&

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -997,8 +997,12 @@ Queue.prototype.processJob = function(job, notFetch = false) {
      * I don't know why instanceof redis.Cluster isn't working
      */
     // if (this.client instanceof redis.Cluster) {
-    if (this.client.options.retryDelayOnClusterDown) {
-      log.warn({ instance: 'redis.Cluster' }, 'handleFailed');
+    if (
+      this.client &&
+      this.client.options &&
+      this.client.options.retryDelayOnClusterDown
+    ) {
+      // log.warn({ instance: 'redis.Cluster' }, 'handleFailed');
       return job.moveToCompleted(err, undefined, notFetch).then(jobData => {
         this.emit('completed', job, err, 'active');
         return jobData ? this.nextJobFromJobData(jobData[0], jobData[1]) : null;

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -942,6 +942,7 @@ Queue.prototype._processJobOnNextTick = function(
 };
 
 Queue.prototype.processJob = function(job, notFetch = false) {
+  console.log('processJob');
   let lockRenewId;
   let timerStopped = false;
 
@@ -991,9 +992,12 @@ Queue.prototype.processJob = function(job, notFetch = false) {
   };
 
   const handleFailed = err => {
-    log.info({queue: this}, 'handleFailed');
-    log.info({client: this.client}, 'handleFailed');
+    log.warn({queue: this}, 'handleFailed');
+    log.warn({client: this.client}, 'handleFailed');
+    console.log({queue: this});
+    console.log({client: this.client});
     if (this.client instanceof redis.Cluster) {
+      log.warn({instance: 'redis.Cluster'}, 'handleFailed');
       return job.moveToCompleted(err, undefined, notFetch).then(jobData => {
         this.emit('completed', job, err, 'active');
         return jobData ? this.nextJobFromJobData(jobData[0], jobData[1]) : null;

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -88,8 +88,6 @@ const Queue = function Queue(name, url, opts) {
   if (!(this instanceof Queue)) {
     return new Queue(name, url, opts);
   }
-  console.log('New Bull Queue');
-  console.log(opts);
 
   if (_.isString(url)) {
     opts = _.extend(
@@ -147,10 +145,6 @@ const Queue = function Queue(name, url, opts) {
   const lazyClient = redisClientGetter(this, opts, (type, client) => {
     // bubble up Redis error events
     client.on('error', this.emit.bind(this, 'error'));
-
-    console.log('lazyClient');
-    console.log(type);
-    console.log(client);
 
     if (type === 'client') {
       this._initializing = commands(client).then(
@@ -996,14 +990,12 @@ Queue.prototype.processJob = function(job, notFetch = false) {
   };
 
   const handleFailed = err => {
-    console.log('handleFailed');
-    console.log(this.client);
-    console.log('handleFailed JSON');
-    console.log(JSON.stringify(this.client));
-    // return job.moveToCompleted(err, undefined, notFetch).then(jobData => {
-    //   this.emit('completed', job, err, 'active');
-    //   return jobData ? this.nextJobFromJobData(jobData[0], jobData[1]) : null;
-    // });
+    if (this.client instanceof redis.Cluster) {
+      return job.moveToCompleted(err, undefined, notFetch).then(jobData => {
+        this.emit('completed', job, err, 'active');
+        return jobData ? this.nextJobFromJobData(jobData[0], jobData[1]) : null;
+      });
+    }
 
     const error = err;
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -23,6 +23,7 @@ const pTimeout = require('p-timeout');
 const semver = require('semver');
 const debuglog = require('debuglog')('bull');
 const uuid = require('uuid');
+const log = require('./log');
 
 const commands = require('./commands/');
 
@@ -990,6 +991,8 @@ Queue.prototype.processJob = function(job, notFetch = false) {
   };
 
   const handleFailed = err => {
+    log.info({queue: this}, 'handleFailed');
+    log.info({client: this.client}, 'handleFailed');
     if (this.client instanceof redis.Cluster) {
       return job.moveToCompleted(err, undefined, notFetch).then(jobData => {
         this.emit('completed', job, err, 'active');

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -991,11 +991,8 @@ Queue.prototype.processJob = function(job, notFetch = false) {
   };
 
   const handleFailed = err => {
-    // log.warn({queue: this}, 'handleFailed');
     // log.warn({client: this.client}, 'handleFailed');
-    // console.log({queue: this});
-
-    // console.log({client: this.client}); // shows `Cluster {` as the first line
+    // console.log({client: this.client}); // shows `Cluster {` as the first line on AWS
     /**
      * I don't know why instanceof redis.Cluster isn't working
      */

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -995,7 +995,6 @@ Queue.prototype.processJob = function(job, notFetch = false) {
      * For some reason I can't check `this.client instanceof redis.Cluster`
      * So instead I'm looking for an option that only exists on a cluster
      */
-    log.warn({client: this.client}, 'handleFailed');
     if (
       this.client &&
       this.client.options &&

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -148,6 +148,10 @@ const Queue = function Queue(name, url, opts) {
     // bubble up Redis error events
     client.on('error', this.emit.bind(this, 'error'));
 
+    console.log('lazyClient');
+    console.log(type);
+    console.log(client);
+
     if (type === 'client') {
       this._initializing = commands(client).then(
         () => {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -993,6 +993,7 @@ Queue.prototype.processJob = function(job, notFetch = false) {
   const handleFailed = err => {
 
     console.log('handleFailed');
+    console.log(redis);
     console.log(this.client);
     // if (this.client instanceof redis.Redis) {
     //   console.log('REDIS');

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -88,6 +88,8 @@ const Queue = function Queue(name, url, opts) {
   if (!(this instanceof Queue)) {
     return new Queue(name, url, opts);
   }
+  console.log('New Bull Queue');
+  console.log(opts);
 
   if (_.isString(url)) {
     opts = _.extend(
@@ -990,6 +992,11 @@ Queue.prototype.processJob = function(job, notFetch = false) {
   };
 
   const handleFailed = err => {
+    // return job.moveToCompleted(err, undefined, notFetch).then(jobData => {
+    //   this.emit('completed', job, err, 'active');
+    //   return jobData ? this.nextJobFromJobData(jobData[0], jobData[1]) : null;
+    // });
+
     const error = err;
 
     return job.moveToFailed(err).then(jobData => {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -942,7 +942,6 @@ Queue.prototype._processJobOnNextTick = function(
 };
 
 Queue.prototype.processJob = function(job, notFetch = false) {
-  console.log('processJob');
   let lockRenewId;
   let timerStopped = false;
 
@@ -992,13 +991,17 @@ Queue.prototype.processJob = function(job, notFetch = false) {
   };
 
   const handleFailed = err => {
-    log.warn({queue: this}, 'handleFailed');
-    log.warn({client: this.client}, 'handleFailed');
+    // log.warn({queue: this}, 'handleFailed');
+    // log.warn({client: this.client}, 'handleFailed');
     // console.log({queue: this});
-    // console.log({client: this.client});
+
+    // console.log({client: this.client}); // shows `Cluster {` as the first line
+    /**
+     * I don't know why instanceof redis.Cluster isn't working
+     */
     // if (this.client instanceof redis.Cluster) {
     if (this.client.options.retryDelayOnClusterDown) {
-      log.warn({instance: 'redis.Cluster'}, 'handleFailed');
+      log.warn({ instance: 'redis.Cluster' }, 'handleFailed');
       return job.moveToCompleted(err, undefined, notFetch).then(jobData => {
         this.emit('completed', job, err, 'active');
         return jobData ? this.nextJobFromJobData(jobData[0], jobData[1]) : null;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
+    "bunyan": "1.8.12",
     "cron-parser": "^2.7.3",
     "debuglog": "^1.0.0",
     "get-port": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -468,6 +468,16 @@ browser-stdout@1.3.1:
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
+bunyan@1.8.12:
+  version "1.8.12"
+  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.12.tgz#f150f0f6748abdd72aeae84f04403be2ef113797"
+  integrity sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=
+  optionalDependencies:
+    dtrace-provider "~0.8"
+    moment "^2.10.6"
+    mv "~2"
+    safe-json-stringify "~1"
+
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -924,6 +934,13 @@ dot-prop@^3.0.0:
   integrity sha1-G3CK8JSknJoOfbyteQq6U52sEXc=
   dependencies:
     is-obj "^1.0.0"
+
+dtrace-provider@~0.8:
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.7.tgz#dc939b4d3e0620cfe0c1cd803d0d2d7ed04ffd04"
+  integrity sha1-3JObTT4GIM/gwc2APQ0tftBP/QQ=
+  dependencies:
+    nan "^2.10.0"
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -1432,6 +1449,17 @@ glob@^5.0.15:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
   integrity sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^6.0.1:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  integrity sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=
   dependencies:
     inflight "^1.0.4"
     inherits "2"
@@ -2420,7 +2448,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -2468,7 +2496,7 @@ moment-timezone@^0.5.23:
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0", moment@^2.24.0:
+"moment@>= 2.9.0", moment@^2.10.6, moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
@@ -2487,6 +2515,20 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
+
+mv@~2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"
+  integrity sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=
+  dependencies:
+    mkdirp "~0.5.1"
+    ncp "~2.0.0"
+    rimraf "~2.4.0"
+
+nan@^2.10.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
+  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -2509,6 +2551,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+ncp@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+  integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
 neo-async@^2.6.0:
   version "2.6.1"
@@ -3147,6 +3194,13 @@ rimraf@2.6.3, rimraf@^2.2.8, rimraf@^2.5.2:
   dependencies:
     glob "^7.1.3"
 
+rimraf@~2.4.0:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.4.5.tgz#ee710ce5d93a8fdb856fb5ea8ff0e2d75934b2da"
+  integrity sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=
+  dependencies:
+    glob "^6.0.1"
+
 run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
@@ -3170,6 +3224,11 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-json-stringify@~1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz#356e44bc98f1f93ce45df14bcd7c01cda86e0afd"
+  integrity sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==
 
 safe-regex@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
I tried to check for `instanceof redis.Cluster`, but for some reason it's not evaluating to true, so I had to go with an options check.  It's difficult to debug as well, because we're not running in cluster mode locally, only on AWS.  See inline comments for more detail - if anyone has any ideas on a better check, let me know.